### PR TITLE
Fix integer overflow when determine system memory size

### DIFF
--- a/source/build/src/compat.cpp
+++ b/source/build/src/compat.cpp
@@ -612,7 +612,7 @@ uint32_t Bgetsysmemsize(void)
     int64_t const scphyspages = sysconf(_SC_PHYS_PAGES);
 
     if (scpagesiz >= 0 && scphyspages >= 0)
-        siz = min<uint32_t>(UINT32_MAX, scpagesiz * scphyspages);
+        siz = (uint32_t)min<uint64_t>(UINT32_MAX, scpagesiz * scphyspages);
 
     //initprintf("Bgetsysmemsize(): %d pages of %d bytes, %d bytes of system memory\n",
     //		scphyspages, scpagesiz, siz);


### PR DESCRIPTION
This is the same issue and patch from NBlood by @alexey-lysiuk https://github.com/nukeykt/NBlood/commit/a5b94428990ddecd17f129d1f0ba068699a6ff1a

Fixes "ERROR: BUFFER TOO BIG TO FIT IN CACHE!" crash on macOS.